### PR TITLE
add missing mime package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "is-css-color": "^1.0.0",
     "lodash": "^3.10.1",
     "md5": "^2.0.0",
+    "mime": "^1.3.4",
     "react": "^0.13.3",
     "reflux": "^0.2.12",
     "c3": "https://github.com/princejwesley/c3.git"


### PR DESCRIPTION
I was receiving an error about a missing "mime" package in MacOS X after building.

I'm building under NodeJS 4.2.2 with npm 3.3.12; perhaps the npm version is to blame.