### PR TITLE
Build fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["add-module-exports"]
+  "plugins": ["add-module-exports", "transform-runtime"]
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,6 +23,7 @@ const nodeResources = (() => {
   return _.chain(result.toString().trim().split(/\r?\n/))
     // remove app root path
     .tap((r) => r.shift())
+    .filter((dep) => dep.match(/node_modules/g).length == 1)
     .map((dep) => `${dep}/**/*.{js,css,json,svg,png,gif,woff2,otf,ttf,woff,eot,ts}`)
     .value();
 })();


### PR DESCRIPTION
Addresses a few issues:

- Use local binaries for npm scripts to reduce dependencies on global tools such as Gulp
- Font Awesome was not being included in the build directory
- Babel errors resulting from missing the transform runtime plugin
- Optimize the copy Gulp task by only adding top-level node deps to the list of resources