### PR TITLE
Page zoom preference display

### DIFF
--- a/src/components/ReplPageZoom.js
+++ b/src/components/ReplPageZoom.js
@@ -15,7 +15,7 @@ export default class ReplPageZoom extends React.Component {
   }
 
   getZoomPercentage(zoom) {
-    return `${parseInt(zoom * 100)}%`;
+    return `${(zoom * 100).toFixed()}%`;
   }
   render() {
     let zoom = global.Mancy.preferences.pageZoomFactor;

--- a/src/components/ReplPageZoom.js
+++ b/src/components/ReplPageZoom.js
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import ReplPreferencesActions from '../actions/ReplPreferencesActions';
 
-const zoomOptions = [0.75, 0.9, 1, 1.1, 1.2, 1.25, 1.3, 1.4, 1.5, 1.6, 1.7, 1.75, 1.8, 1,9, 2, 2.1, 2.2, 2.25, 2.3, 2.4, 2.5];
+const zoomOptions = [0.75, 0.9, 1, 1.1, 1.2, 1.25, 1.3, 1.4, 1.5, 1.6, 1.7, 1.75, 1.8, 1.9, 2, 2.1, 2.2, 2.25, 2.3, 2.4, 2.5];
 export default class ReplPageZoom extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Displaying 100% twice next to 900%. I am assuming this is meant to be a single value of 190%. Additionally, the list displays 229% with a value of 2.3. This was determined to be an issue with JS's floating point precision.
![capture_1455817335415](https://cloud.githubusercontent.com/assets/1950982/13152427/2306b15c-d63d-11e5-92e6-bccac777e1ba.png)