### PR TITLE
Add support for preview of React elements

### DIFF
--- a/src/common/ReplOutput.js
+++ b/src/common/ReplOutput.js
@@ -12,6 +12,7 @@ import ReplOutputArray from '../components/ReplOutputArray';
 import ReplOutputObject from '../components/ReplOutputObject';
 import ReplOutputInteger from '../components/ReplOutputInteger';
 import ReplOutputPromise from '../components/ReplOutputPromise';
+import ReplOutputReactElement from '../components/ReplOutputReactElement';
 import ReplOutputRegex from '../components/ReplOutputRegex';
 import ReplOutputString from '../components/ReplOutputString';
 import ReplOutputColor from '../components/ReplOutputColor';
@@ -37,10 +38,6 @@ let makeMirror = (o) => Debug.MakeMirror(o, true);
 let BabelCoreJS = require("babel-runtime/core-js");
 
 let getObjectLabels = (o) => {
-  if(o._isReactElement) {
-    return ' ReactElement {}';
-  }
-
   if(o instanceof Error) {
     return ` ${o.name} {}`;
   }
@@ -121,6 +118,10 @@ let ReplOutputType = {
     return <ReplOutputDate date={d} />
   },
   object: (o) => {
+
+    if(o._isReactElement) {
+        return <ReplOutputReactElement element={o} />;
+    }
 
     if(_.isError(o)) {
       let [first, ...rest] = o.stack.split(EOL);

--- a/src/components/ReplOutputReactElement.js
+++ b/src/components/ReplOutputReactElement.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default class ReplOutputReactElement extends React.Component {
+  componentDidMount() {
+      const iframe = this.refs.iframe.getDOMNode();
+      const iframeBody = iframe.contentDocument.body;
+      React.render(this.props.element, iframeBody);
+
+      // first it's set to zero on purpose
+      // check: http://stackoverflow.com/a/20722176/4804689
+      iframe.height = 0;
+
+      // actually adjust height
+      iframe.height = iframeBody.scrollHeight + 'px';
+  }
+
+  render() {
+    return (
+        <iframe
+          style={{border: 'none'}}
+          ref="iframe">
+        </iframe>
+    );
+  }
+}


### PR DESCRIPTION
I made a preview feature for React elements:

I mean. It looked this way:
![image](https://cloud.githubusercontent.com/assets/3883359/14125071/8e69ed88-f609-11e5-8ed2-b3cf95646b48.png)

Now when Mancy detects React element it renders a preview:
![image](https://cloud.githubusercontent.com/assets/3883359/14126748/88cbcbf8-f613-11e5-8440-d59806354b44.png)

